### PR TITLE
Add replace deleted video functionality

### DIFF
--- a/src/components/organize/ReplaceVideoDrawer.tsx
+++ b/src/components/organize/ReplaceVideoDrawer.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, Search, AlertCircle } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "~/components/ui/drawer";
+import { getOriginalVideoTitle, searchYouTube, type YouTubeSearchResult } from "~/lib/videoReplace";
+import { env } from "~/env";
+import { useAuth } from "~/components/auth/useAuth";
+
+type ReplaceVideoDrawerProps = {
+  children: React.ReactNode;
+  videoId: string | undefined;
+  onReplaceVideo: (newVideoId: string) => Promise<void>;
+};
+
+type LoadingState = "idle" | "fetching-title" | "searching" | "replacing";
+
+export function ReplaceVideoDrawer({ children, videoId, onReplaceVideo }: ReplaceVideoDrawerProps) {
+  const auth = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const [loadingState, setLoadingState] = useState<LoadingState>("idle");
+  const [originalTitle, setOriginalTitle] = useState<string | null>(null);
+  const [searchResults, setSearchResults] = useState<YouTubeSearchResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state when drawer opens
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      setLoadingState("idle");
+      setOriginalTitle(null);
+      setSearchResults([]);
+      setError(null);
+    }
+  }, []);
+
+  // Automatically start the search process when drawer opens
+  useEffect(() => {
+    if (!isOpen || !videoId) return;
+    
+    async function searchForAlternatives() {
+      try {
+        // Step 1: Try to get the original title from Wayback Machine
+        setLoadingState("fetching-title");
+        setError(null);
+        
+        const title = await getOriginalVideoTitle(videoId!);
+        
+        if (!title) {
+          setError("Could not find the original video title in the Wayback Machine archive. The video may not have been archived.");
+          setLoadingState("idle");
+          return;
+        }
+        
+        setOriginalTitle(title);
+        
+        // Step 2: Search YouTube for alternatives
+        setLoadingState("searching");
+        
+        const results = await searchYouTube({
+          query: title,
+          apiKey: env.NEXT_PUBLIC_YOUTUBE_API_KEY,
+          accessToken: auth.accessToken,
+          maxResults: 10,
+          refreshToken: auth.getTokenSilently,
+        });
+        
+        setSearchResults(results);
+        setLoadingState("idle");
+        
+        if (results.length === 0) {
+          setError("No alternative videos found for this title.");
+        }
+      } catch (err) {
+        console.error("Error searching for alternatives:", err);
+        setError((err as Error)?.message ?? "An error occurred while searching for alternatives.");
+        setLoadingState("idle");
+      }
+    }
+    
+    searchForAlternatives();
+  }, [isOpen, videoId, auth.accessToken, auth.getTokenSilently]);
+
+  const handleSelectVideo = useCallback(async (selectedVideoId: string) => {
+    setLoadingState("replacing");
+    setError(null);
+    
+    try {
+      await onReplaceVideo(selectedVideoId);
+      setIsOpen(false);
+    } catch (err) {
+      console.error("Error replacing video:", err);
+      setError((err as Error)?.message ?? "Failed to replace video.");
+      setLoadingState("idle");
+    }
+  }, [onReplaceVideo]);
+
+  const isLoading = loadingState !== "idle";
+
+  return (
+    <Drawer open={isOpen} onOpenChange={handleOpenChange}>
+      <DrawerTrigger asChild>
+        {children}
+      </DrawerTrigger>
+      <DrawerContent>
+        <div className="mx-auto w-full max-w-2xl max-h-[80vh] flex flex-col">
+          <DrawerHeader>
+            <DrawerTitle>Search for Alternatives</DrawerTitle>
+            <DrawerDescription>
+              The original video was removed, but we&apos;ve attempted to find alternative versions.
+            </DrawerDescription>
+          </DrawerHeader>
+          
+          <div className="flex-1 overflow-y-auto px-4">
+            {/* Loading state */}
+            {loadingState === "fetching-title" && (
+              <div className="flex flex-col items-center justify-center py-12 gap-3">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">Searching Wayback Machine for original title...</p>
+              </div>
+            )}
+            
+            {loadingState === "searching" && (
+              <div className="flex flex-col items-center justify-center py-12 gap-3">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">
+                  Searching YouTube for: <span className="font-medium">{originalTitle}</span>
+                </p>
+              </div>
+            )}
+            
+            {loadingState === "replacing" && (
+              <div className="flex flex-col items-center justify-center py-12 gap-3">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">Replacing video...</p>
+              </div>
+            )}
+            
+            {/* Error state */}
+            {error && loadingState === "idle" && (
+              <div className="flex flex-col items-center justify-center py-12 gap-3">
+                <div className="size-12 rounded-full bg-red-500/10 flex items-center justify-center">
+                  <AlertCircle className="size-6 text-red-500" />
+                </div>
+                <p className="text-sm text-muted-foreground text-center max-w-md">{error}</p>
+              </div>
+            )}
+            
+            {/* Results list */}
+            {!isLoading && !error && searchResults.length > 0 && (
+              <div className="space-y-3 pb-4">
+                {originalTitle && (
+                  <div className="pb-2 border-b">
+                    <p className="text-sm text-muted-foreground">
+                      Original title: <span className="font-medium text-foreground">{originalTitle}</span>
+                    </p>
+                  </div>
+                )}
+                
+                <div className="space-y-2">
+                  {searchResults.map((result) => (
+                    <button
+                      key={result.videoId}
+                      type="button"
+                      onClick={() => handleSelectVideo(result.videoId)}
+                      className="w-full flex items-start gap-3 p-3 rounded-lg border hover:bg-secondary transition-colors text-left"
+                    >
+                      {/* Thumbnail */}
+                      {result.thumbnailUrl && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={result.thumbnailUrl}
+                          alt="thumbnail"
+                          className="h-20 w-36 rounded object-cover flex-shrink-0"
+                        />
+                      )}
+                      
+                      {/* Content */}
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium line-clamp-2">{result.title}</p>
+                        <p className="text-sm text-muted-foreground mt-1">{result.channelTitle}</p>
+                        {result.description && (
+                          <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                            {result.description}
+                          </p>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            
+            {/* Empty state when not loading and no results */}
+            {!isLoading && !error && searchResults.length === 0 && loadingState === "idle" && (
+              <div className="flex flex-col items-center justify-center py-12 gap-3">
+                <Search className="h-8 w-8 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">Click to search for alternatives</p>
+              </div>
+            )}
+          </div>
+          
+          <DrawerFooter>
+            <DrawerClose asChild>
+              <Button variant="outline" disabled={isLoading}>
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/lib/videoReplace.ts
+++ b/src/lib/videoReplace.ts
@@ -1,0 +1,175 @@
+/**
+ * Utilities for finding replacement videos for deleted YouTube videos
+ */
+
+export type WaybackMachineSnapshot = {
+  timestamp: string;
+  status: string;
+  url: string;
+  title?: string;
+};
+
+export type YouTubeSearchResult = {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  channelId: string;
+  thumbnailUrl?: string;
+  description?: string;
+  publishedAt?: string;
+};
+
+/**
+ * Attempts to retrieve the original video title from Wayback Machine
+ */
+export async function getOriginalVideoTitle(
+  videoId: string
+): Promise<string | null> {
+  try {
+    const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    
+    // First, check if the URL has been archived
+    const cdxUrl = new URL("https://web.archive.org/cdx/search/cdx");
+    cdxUrl.searchParams.set("url", videoUrl);
+    cdxUrl.searchParams.set("output", "json");
+    cdxUrl.searchParams.set("limit", "1");
+    cdxUrl.searchParams.set("filter", "statuscode:200");
+    
+    const cdxRes = await fetch(cdxUrl.toString());
+    if (!cdxRes.ok) return null;
+    
+    const cdxData = await cdxRes.json() as string[][];
+    if (!cdxData || cdxData.length < 2) return null;
+    
+    // Get the snapshot timestamp (format: YYYYMMDDhhmmss)
+    const snapshot = cdxData[1];
+    if (!snapshot) return null;
+    const timestamp = snapshot[1];
+    
+    // Fetch the archived page
+    const archiveUrl = `https://web.archive.org/web/${timestamp}/${videoUrl}`;
+    const archiveRes = await fetch(archiveUrl);
+    if (!archiveRes.ok) return null;
+    
+    const html = await archiveRes.text();
+    
+    // Try to extract title from various meta tags and title element
+    // YouTube uses various formats, try them all
+    const patterns = [
+      /<meta property="og:title" content="([^"]+)"/,
+      /<meta name="title" content="([^"]+)"/,
+      /<title>([^<]+)<\/title>/,
+    ];
+    
+    for (const pattern of patterns) {
+      const match = html.match(pattern);
+      if (match?.[1]) {
+        let title = match[1]
+          .replace(/ - YouTube$/, "") // Remove " - YouTube" suffix
+          .trim();
+        if (title && title !== "YouTube") {
+          return title;
+        }
+      }
+    }
+    
+    return null;
+  } catch (error) {
+    console.error("Error fetching from Wayback Machine:", error);
+    return null;
+  }
+}
+
+/**
+ * Searches YouTube for videos matching the given query
+ */
+export async function searchYouTube({
+  query,
+  apiKey,
+  accessToken,
+  maxResults = 10,
+  refreshToken,
+}: {
+  query: string;
+  apiKey?: string;
+  accessToken?: string;
+  maxResults?: number;
+  refreshToken?: () => Promise<string | null>;
+}): Promise<YouTubeSearchResult[]> {
+  const url = new URL("https://www.googleapis.com/youtube/v3/search");
+  url.searchParams.set("part", "snippet");
+  url.searchParams.set("q", query);
+  url.searchParams.set("type", "video");
+  url.searchParams.set("maxResults", String(Math.min(50, Math.max(1, maxResults))));
+  url.searchParams.set("order", "relevance");
+  
+  const headers: Record<string, string> = {};
+  
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  } else if (apiKey) {
+    url.searchParams.set("key", apiKey);
+  }
+  
+  let res = await fetch(url.toString(), { headers });
+  
+  // If unauthorized and we have a refresh function, try to refresh token and retry
+  if (res.status === 401 && accessToken && refreshToken) {
+    const freshToken = await refreshToken();
+    if (freshToken) {
+      headers["Authorization"] = `Bearer ${freshToken}`;
+      res = await fetch(url.toString(), { headers });
+    }
+  }
+  
+  // If still unauthorized and we have an API key, retry without Authorization header
+  if (res.status === 401 && apiKey) {
+    try {
+      const retryUrl = new URL(url.toString());
+      retryUrl.searchParams.set("key", apiKey);
+      res = await fetch(retryUrl.toString());
+    } catch {
+      // fall through to error handling
+    }
+  }
+  
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `YouTube Search API error: ${res.status} ${res.statusText} ${text}`
+    );
+  }
+  
+  const json = (await res.json()) as {
+    items?: Array<{
+      id?: { videoId?: string };
+      snippet?: {
+        title?: string;
+        channelTitle?: string;
+        channelId?: string;
+        description?: string;
+        thumbnails?: {
+          default?: { url?: string };
+          medium?: { url?: string };
+          high?: { url?: string };
+        };
+        publishedAt?: string;
+      };
+    }>;
+  };
+  
+  return (json.items ?? [])
+    .filter((item) => item.id?.videoId && item.snippet)
+    .map((item) => ({
+      videoId: item.id!.videoId!,
+      title: item.snippet!.title ?? "Untitled",
+      channelTitle: item.snippet!.channelTitle ?? "Unknown",
+      channelId: item.snippet!.channelId ?? "",
+      thumbnailUrl:
+        item.snippet!.thumbnails?.high?.url ||
+        item.snippet!.thumbnails?.medium?.url ||
+        item.snippet!.thumbnails?.default?.url,
+      description: item.snippet!.description,
+      publishedAt: item.snippet!.publishedAt,
+    }));
+}


### PR DESCRIPTION
Add a "Search for Alternatives" feature for deleted YouTube videos to allow users to replace them in their playlists.

When YouTube videos are removed, they currently appear as "Deleted Video" with no recovery option. This PR introduces a mechanism to find the original video title via the Wayback Machine and then search YouTube for alternative versions, providing a way for users to maintain their playlists.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ad7a3c3-d258-4b5b-b753-64a009e68028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ad7a3c3-d258-4b5b-b753-64a009e68028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

