### PR TITLE
Hide system bar and disable zoom

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Sleepytime-YouTube",
+  "short_name": "Sleepytime",
+  "description": "Play YouTube playlists one by one",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#252525",
+  "theme_color": "#252525",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
 import "~/styles/globals.css";
 import { AppProviders } from "./providers";
@@ -7,9 +7,28 @@ import { AuroraBackground } from "./AuroraBackground";
 import { Toaster } from "sonner";
 import { BottomNav } from "~/components/BottomNav";
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: "cover",
+};
+
 export const metadata: Metadata = {
   title: "Sleepytime-YouTube",
   description: "Play YouTube playlists one by one",
+  applicationName: "Sleepytime-YouTube",
+  manifest: "/manifest.json",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Sleepytime-YouTube",
+  },
+  formatDetection: {
+    telephone: false,
+  },
+  themeColor: "#252525",
 };
 
 const geist = Geist({ subsets: ["latin"] });


### PR DESCRIPTION
Configure iOS web app settings and PWA manifest to style the status bar and disable zoom gestures for a native app feel on iPad.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab195e46-8aa6-4de6-bbae-9a6b69200406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab195e46-8aa6-4de6-bbae-9a6b69200406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

