### PR TITLE
Fix duplicate viewport declaration in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,12 +31,6 @@ export const metadata: Metadata = {
   themeColor: "#252525",
 };
 
-export const viewport: Viewport = {
-  width: "device-width",
-  initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
-};
 
 const geist = Geist({ subsets: ["latin"] });
 


### PR DESCRIPTION
Remove duplicate `viewport` export to fix build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f32daaa0-407a-4049-a866-950c21cee240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f32daaa0-407a-4049-a866-950c21cee240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

