### PR TITLE
Fix drag and drop on touch screens

### DIFF
--- a/src/app/organize/page.tsx
+++ b/src/app/organize/page.tsx
@@ -11,7 +11,7 @@ import { SkeletonPlaylistDetail } from "~/components/organize/SkeletonPlaylistDe
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { env } from "~/env";
-import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { DndContext, DragOverlay, PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
 import type { DragStartEvent, DragEndEvent } from "@dnd-kit/core";
 import { PlaylistDetail } from "~/components/organize/PlaylistDetail";
 
@@ -35,6 +35,12 @@ export default function OrganizePage() {
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 5,
       },
     })
   );

--- a/src/components/organize/SortableVideoList.tsx
+++ b/src/components/organize/SortableVideoList.tsx
@@ -93,7 +93,7 @@ function SortableVideoItem({ item, onDelete, disableDragDrop, onReplaceVideo }: 
           <button
             type="button"
             ref={setActivatorNodeRef}
-            className="w-10 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-grab active:cursor-grabbing self-stretch flex-shrink-0 touch-none"
+            className="w-10 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-grab active:cursor-grabbing self-stretch flex-shrink-0 touch-manipulation select-none"
             aria-label="Drag to reorder"
             {...attributes}
             {...listeners}

--- a/src/components/playlist/Player.tsx
+++ b/src/components/playlist/Player.tsx
@@ -27,6 +27,7 @@ import {
   closestCenter,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -148,7 +149,7 @@ function SortablePlaylistItem({ item, isCurrent, isAuthenticated, onSelect, onDe
           ref={setActivatorNodeRef}
           className={`w-8 inline-flex items-center justify-center rounded transition-colors self-stretch flex-shrink-0 ml-1 ${
             isAuthenticated && item.videoId
-              ? "text-white hover:text-white/80 hover:bg-secondary/50 cursor-grab active:cursor-grabbing touch-none"
+              ? "text-white hover:text-white/80 hover:bg-secondary/50 cursor-grab active:cursor-grabbing touch-manipulation select-none"
               : "text-muted-foreground/30 cursor-not-allowed"
           }`}
           aria-label="Drag to reorder"
@@ -272,6 +273,12 @@ export function Player() {
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 5,
       },
     }),
     useSensor(KeyboardSensor, {


### PR DESCRIPTION
Add `TouchSensor` to `@dnd-kit` configurations and improve touch CSS to enable drag and drop functionality on touch screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-f80110eb-6bf1-4622-a847-94b9f76dcf08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f80110eb-6bf1-4622-a847-94b9f76dcf08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

