### PR TITLE
Fix sidebar scrolling during video reorder

### DIFF
--- a/src/components/organize/SortableVideoList.tsx
+++ b/src/components/organize/SortableVideoList.tsx
@@ -95,7 +95,7 @@ function SortableVideoItem({ item, onDelete, disableDragDrop, onReplaceVideo, ca
           <button
             type="button"
             ref={setActivatorNodeRef}
-            className="w-10 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-grab active:cursor-grabbing self-stretch flex-shrink-0 touch-manipulation select-none"
+            className="w-10 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-grab active:cursor-grabbing self-stretch flex-shrink-0 touch-manipulation select-none touch-drag-handle"
             aria-label="Drag to reorder"
             {...attributes}
             {...listeners}

--- a/src/components/playlist/Player.tsx
+++ b/src/components/playlist/Player.tsx
@@ -149,7 +149,7 @@ function SortablePlaylistItem({ item, isCurrent, canEdit, onSelect, onDelete }: 
           <button
             type="button"
             ref={setActivatorNodeRef}
-            className="w-8 inline-flex items-center justify-center rounded transition-colors self-stretch flex-shrink-0 ml-1 text-white hover:text-white/80 hover:bg-secondary/50 cursor-grab active:cursor-grabbing touch-manipulation select-none"
+            className="w-8 inline-flex items-center justify-center rounded transition-colors self-stretch flex-shrink-0 ml-1 text-white hover:text-white/80 hover:bg-secondary/50 cursor-grab active:cursor-grabbing touch-manipulation select-none touch-drag-handle"
             aria-label="Drag to reorder"
             onClick={(e) => e.stopPropagation()}
             {...attributes}
@@ -280,6 +280,7 @@ export function Player() {
   const dialogShownForVideoRef = useRef<string | undefined>(undefined);
   const timeCheckIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [sortOrder, setSortOrder] = useState<"first-added" | "last-added">("first-added");
+  const [isDragging, setIsDragging] = useState<boolean>(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -289,8 +290,8 @@ export function Player() {
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
-        delay: 250,
-        tolerance: 5,
+        delay: 100,
+        tolerance: 8,
       },
     }),
     useSensor(KeyboardSensor, {
@@ -457,8 +458,13 @@ export function Player() {
     [auth.isAuthenticated, auth.accessToken, currentVideoId, playlist, getNextVideoId]
   );
 
+  const handleDragStart = useCallback(() => {
+    setIsDragging(true);
+  }, []);
+
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      setIsDragging(false);
       const { active, over } = event;
 
       if (!over || active.id === over.id) return;
@@ -936,10 +942,11 @@ export function Player() {
           </div>
 
           {/* Playlist items - scrollable */}
-          <div className="flex-1 overflow-y-auto pr-2 -mr-2 pt-2">
+          <div className={`flex-1 pr-2 -mr-2 pt-2 touch-drag-container ${isDragging ? 'dragging' : 'overflow-y-auto'}`}>
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
+              onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
             >
               <SortableContext

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -240,4 +240,24 @@
     background-color: #22c55e; /* Tailwind green-500 */
     animation: led-breathe 2.2s ease-in-out infinite;
   }
+
+  /* Touch drag improvements */
+  .touch-drag-handle {
+    touch-action: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .touch-drag-container {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .touch-drag-container.dragging {
+    overflow: hidden !important;
+    -webkit-overflow-scrolling: auto;
+  }
 }


### PR DESCRIPTION
Enable touch drag-and-drop reordering in the sidebar by resolving scroll conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e2abd50-8d4f-4bb8-9733-34be7bd0a300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e2abd50-8d4f-4bb8-9733-34be7bd0a300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

