### PR TITLE
Update sidebar playlist author link display

### DIFF
--- a/src/components/playlist/Player.tsx
+++ b/src/components/playlist/Player.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Shuffle, SkipForward, Moon, Github, Linkedin, ExternalLink, GripVertical, Loader2, Trash2, Play, Pause, ArrowUpDown, ListVideo } from "lucide-react";
+import { Shuffle, SkipForward, Moon, Github, Linkedin, ExternalLink, GripVertical, Loader2, Trash2, Play, Pause, ArrowUpDown, ListVideo, ChevronRight } from "lucide-react";
 import { usePlaylist } from "~/components/playlist/PlaylistContext";
 import { SleepTimerDrawer } from "~/components/playlist/SleepTimerDrawer";
 import { useAuth } from "~/components/auth/useAuth";
@@ -179,19 +179,7 @@ function SortablePlaylistItem({ item, isCurrent, canEdit, onSelect, onDelete }: 
           </div>
           {item.channelTitle && (
             <div className="flex flex-col gap-1">
-              {item.channelId ? (
-                <a
-                  href={`https://www.youtube.com/channel/${item.channelId}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {item.channelTitle}
-                </a>
-              ) : (
-                <p className="text-xs text-muted-foreground">{item.channelTitle}</p>
-              )}
+              <p className="text-xs text-muted-foreground">{item.channelTitle}</p>
               {isCurrent && (
                 <span className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs text-muted-foreground w-fit">
                   <span className="h-1.5 w-1.5 rounded-full bg-green-500 shadow-[0_0_6px_theme(colors.green.500)]" />
@@ -784,7 +772,15 @@ export function Player() {
                 {current?.title ?? ""}
               </h2>
               {current?.channelTitle && (
-                <p className="text-sm text-muted-foreground truncate">{current.channelTitle}</p>
+                <a
+                  href={`https://www.youtube.com/channel/${current.channelId || ''}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors truncate inline-flex items-center gap-1 w-fit"
+                >
+                  {current.channelTitle}
+                  <ChevronRight className="h-3 w-3 flex-shrink-0" />
+                </a>
               )}
             </div>
 


### PR DESCRIPTION
Remove author links from sidebar playlist items and add a right arrow to the channel link below the video to improve usability and visibility.

Users reported accidentally clicking channel links in the sidebar when trying to select videos. This change ensures only the main channel link below the video is clickable, and it's now visually enhanced with an arrow to clearly indicate its interactive nature.

---
<a href="https://cursor.com/background-agent?bcId=bc-97c7f45f-8307-4662-b035-f599c30211d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97c7f45f-8307-4662-b035-f599c30211d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

