### PR TITLE
Adjust playlist box layout for full width

### DIFF
--- a/src/components/playlist/PlaylistGrid.tsx
+++ b/src/components/playlist/PlaylistGrid.tsx
@@ -123,7 +123,7 @@ export function PlaylistGrid() {
                 href={`/player?list=${p.id}`}
                 className="block w-full text-left group"
               >
-                <div className="aspect-video w-2/3 overflow-hidden rounded-md border bg-secondary/40 relative">
+                <div className="aspect-video w-full overflow-hidden rounded-md border bg-secondary/40 relative">
                   {p.thumbnailUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={p.thumbnailUrl} alt="thumbnail" className="h-full w-full object-cover scale-110 origin-center group-hover:opacity-90 transition-opacity" />
@@ -184,7 +184,7 @@ export function PlaylistGrid() {
               href={`/player?list=${p.id}`}
               className="block w-full text-left group"
             >
-              <div className="aspect-video w-2/3 overflow-hidden rounded-md border bg-secondary/40 relative">
+              <div className="aspect-video w-full overflow-hidden rounded-md border bg-secondary/40 relative">
                 {p.thumbnailUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img src={p.thumbnailUrl} alt="thumbnail" className="h-full w-full object-cover scale-110 origin-center group-hover:opacity-90 transition-opacity" />


### PR DESCRIPTION
Remove fixed width from playlist boxes to ensure they span full width and adapt responsively.

---
<a href="https://cursor.com/background-agent?bcId=bc-31c75b30-ed6c-475f-bef9-8cfd6dbcab52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31c75b30-ed6c-475f-bef9-8cfd6dbcab52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

