### PR TITLE
Playlist refresh button + queue drawer width/scroll fixes

### DIFF
--- a/src/components/playlist/Player.tsx
+++ b/src/components/playlist/Player.tsx
@@ -282,10 +282,12 @@ export function Player() {
 				canEdit={canEdit}
 				hasMore={playlist.hasMore}
 				snippet={playlist.snippet}
+				isRefreshing={playlist.isRefreshing}
 				onSelectVideo={playlist.setCurrentVideoId}
 				onDeleteItem={handleDeleteItem}
 				onDragEnd={handleDragEnd}
 				onLoadMore={playlist.loadMoreItems}
+				onRefresh={playlist.refresh}
 			/>
 		</>
 	);

--- a/src/components/playlist/PlaylistContext.tsx
+++ b/src/components/playlist/PlaylistContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	createContext,
 	useCallback,
@@ -45,6 +46,7 @@ export type PlaylistState = {
 		channelTitle?: string;
 	};
 	isLoading?: boolean;
+	isRefreshing?: boolean;
 	hasMore?: boolean;
 	error?: string | null;
 	errorDetails?: string | null;
@@ -58,6 +60,7 @@ export type PlaylistActions = {
 		opts?: { currentVideoId?: string },
 	) => Promise<void>;
 	loadMoreItems: () => Promise<void>;
+	refresh: () => Promise<void>;
 	setCurrentVideoId: (videoId: string | undefined) => void;
 	clear: () => void;
 	setSleepTimer: (durationMinutes: number) => void;
@@ -116,6 +119,7 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 	const hasInitializedFromStorage = useRef(false);
 	const pendingVideoIdRef = useRef<string | undefined>(undefined);
 	const auth = useAuth();
+	const queryClient = useQueryClient();
 
 	// React Query hooks
 	const snippetQuery = usePlaylistSnippet(playlistId);
@@ -131,6 +135,9 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 
 	const snippet = snippetQuery.data ?? null;
 	const isLoading = itemsQuery.isLoading && Boolean(playlistId);
+	const isRefreshing =
+		Boolean(playlistId) &&
+		(itemsQuery.isRefetching || snippetQuery.isRefetching);
 	const hasMore = itemsQuery.hasNextPage ?? false;
 	const queryError = snippetQuery.error ?? itemsQuery.error;
 
@@ -221,6 +228,18 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 		}
 	}, [itemsQuery]);
 
+	const refresh = useCallback(async () => {
+		if (!playlistId) return;
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: ["playlistItems", playlistId],
+			}),
+			queryClient.invalidateQueries({
+				queryKey: ["playlistSnippet", playlistId],
+			}),
+		]);
+	}, [playlistId, queryClient]);
+
 	const clear = useCallback(() => {
 		setPlaylistId(undefined);
 		setCurrentVideoIdRaw(undefined);
@@ -256,6 +275,7 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 			currentVideoId,
 			currentVideoMeta,
 			isLoading,
+			isRefreshing,
 			hasMore,
 			error: errorInfo.error,
 			errorDetails: errorInfo.errorDetails,
@@ -263,6 +283,7 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 			isPaused,
 			loadByPlaylistId,
 			loadMoreItems,
+			refresh,
 			setCurrentVideoId,
 			clear,
 			setSleepTimer: sleepTimerActions.setSleepTimer,
@@ -280,12 +301,14 @@ export function PlaylistProvider({ children }: { children: React.ReactNode }) {
 			currentVideoId,
 			currentVideoMeta,
 			isLoading,
+			isRefreshing,
 			hasMore,
 			errorInfo,
 			sleepTimer,
 			isPaused,
 			loadByPlaylistId,
 			loadMoreItems,
+			refresh,
 			setCurrentVideoId,
 			clear,
 			sleepTimerActions,

--- a/src/components/playlist/PlaylistSidebar.tsx
+++ b/src/components/playlist/PlaylistSidebar.tsx
@@ -16,7 +16,7 @@ import {
 	sortableKeyboardCoordinates,
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { GripVertical, Loader2 } from "lucide-react";
+import { GripVertical, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { SortablePlaylistItem } from "~/components/playlist/SortablePlaylistItem";
@@ -39,20 +39,24 @@ export function PlaylistSidebar({
 	canEdit,
 	hasMore,
 	snippet,
+	isRefreshing,
 	onSelectVideo,
 	onDeleteItem,
 	onDragEnd,
 	onLoadMore,
+	onRefresh,
 }: {
 	items: YouTubePlaylistItem[];
 	currentVideoId: string | undefined;
 	canEdit: boolean;
 	hasMore: boolean | undefined;
 	snippet?: YouTubePlaylistSnippet | null;
+	isRefreshing?: boolean;
 	onSelectVideo: (videoId?: string) => void;
 	onDeleteItem: (itemId: string) => Promise<void>;
 	onDragEnd: (event: DragEndEvent) => Promise<void>;
 	onLoadMore: () => Promise<void>;
+	onRefresh?: () => Promise<void>;
 }) {
 	const { isFadedOut } = useSleepyFadeout();
 	const [activeItem, setActiveItem] = useState<YouTubePlaylistItem | null>(
@@ -152,6 +156,21 @@ export function PlaylistSidebar({
 							</p>
 						)}
 					</div>
+					{onRefresh && (
+						<button
+							type="button"
+							onClick={() => {
+								void onRefresh();
+							}}
+							disabled={isRefreshing}
+							aria-label="Refresh playlist"
+							className="shrink-0 self-start -mr-1 -mt-1 p-2 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+						>
+							<RefreshCw
+								className={cn("h-4 w-4", isRefreshing && "animate-spin")}
+							/>
+						</button>
+					)}
 				</div>
 			)}
 			<div

--- a/src/components/playlist/PlaylistSidebar.tsx
+++ b/src/components/playlist/PlaylistSidebar.tsx
@@ -174,7 +174,7 @@ export function PlaylistSidebar({
 				</div>
 			)}
 			<div
-				className={`pr-2 -mr-2 touch-drag-container ${activeItem ? "dragging" : ""}`}
+				className={`touch-drag-container ${activeItem ? "dragging" : ""}`}
 			>
 				<DndContext
 					sensors={sensors}

--- a/src/components/playlist/QueueDrawer.tsx
+++ b/src/components/playlist/QueueDrawer.tsx
@@ -62,10 +62,10 @@ export function QueueDrawer({
 			onOpenChange={onOpenChange}
 			handleOnly
 		>
-			<DrawerContent className="gap-0 p-0 data-[vaul-drawer-direction=right]:sm:max-w-md">
+			<DrawerContent className="gap-0 p-0 data-[vaul-drawer-direction=right]:w-[calc(100%-3rem)] data-[vaul-drawer-direction=right]:sm:max-w-md">
 				<DrawerTitle className="sr-only">Queue</DrawerTitle>
 
-				<div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+				<div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain">
 					<PlaylistSidebar
 						items={items}
 						currentVideoId={currentVideoId}

--- a/src/components/playlist/QueueDrawer.tsx
+++ b/src/components/playlist/QueueDrawer.tsx
@@ -34,10 +34,12 @@ export function QueueDrawer({
 	canEdit,
 	hasMore,
 	snippet,
+	isRefreshing,
 	onSelectVideo,
 	onDeleteItem,
 	onDragEnd,
 	onLoadMore,
+	onRefresh,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -46,10 +48,12 @@ export function QueueDrawer({
 	canEdit: boolean;
 	hasMore: boolean | undefined;
 	snippet?: YouTubePlaylistSnippet | null;
+	isRefreshing?: boolean;
 	onSelectVideo: (videoId?: string) => void;
 	onDeleteItem: (itemId: string) => Promise<void>;
 	onDragEnd: (event: DragEndEvent) => Promise<void>;
 	onLoadMore: () => Promise<void>;
+	onRefresh?: () => Promise<void>;
 }) {
 	return (
 		<Drawer
@@ -68,10 +72,12 @@ export function QueueDrawer({
 						canEdit={canEdit}
 						hasMore={hasMore}
 						snippet={snippet}
+						isRefreshing={isRefreshing}
 						onSelectVideo={onSelectVideo}
 						onDeleteItem={onDeleteItem}
 						onDragEnd={onDragEnd}
 						onLoadMore={onLoadMore}
+						onRefresh={onRefresh}
 					/>
 				</div>
 


### PR DESCRIPTION
## Summary

- Refresh icon in the queue drawer's snippet header — invalidates `playlistItems` + `playlistSnippet` for the current playlist, spins + disables while refetching. Covers "I added stuff outside the app, my queue is stale."
- Queue drawer on iPhone widened from `w-3/4` to `calc(100% - 3rem)` (48px tap-dismiss curtain). iPad unchanged at `max-w-md`.
- Killed sideways scroll in the sidebar: dropped the `-mr-2` on the list wrapper that leaked 8px past the parent, plus `overflow-x-hidden` on the drawer's scroll container.

## Test plan

- [x] Refresh button click triggers refetch of both queries, spins during flight, disables to prevent double-fire (verified in headless Chromium with mocked YouTube API).
- [x] iPhone 390 viewport: drawer 342px, 48px left curtain. iPad 820 viewport: drawer 448px unchanged.
- [x] `scrollWidth === clientWidth` and computed `overflow-x: hidden` on both viewports.
- [ ] Sanity check on a real iPhone/iPad against a real YouTube playlist.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LToo8dhBV31qX2QUdyWesi)_