### PR TITLE
Deploy refresh: drive version poll via React Query

### DIFF
--- a/src/components/DeployRefresh.tsx
+++ b/src/components/DeployRefresh.tsx
@@ -43,15 +43,24 @@ export function DeployRefresh() {
 			if (staleRef.current && !isPlayingRef.current) reload();
 		};
 
-		const onVisibilityChange = () => {
+		// Re-check whenever the app comes back to the foreground. Background
+		// tabs throttle the interval, so a reopen is the realistic trigger:
+		// visibilitychange (tab switch), focus (window regains focus), and
+		// pageshow (bfcache restore — the common mobile-PWA reopen, where the
+		// old bundle keeps running and no fresh load happens).
+		const onForeground = () => {
 			if (document.visibilityState === "visible") void check();
 		};
 
 		const interval = setInterval(check, CHECK_INTERVAL_MS);
-		document.addEventListener("visibilitychange", onVisibilityChange);
+		document.addEventListener("visibilitychange", onForeground);
+		window.addEventListener("focus", onForeground);
+		window.addEventListener("pageshow", onForeground);
 		return () => {
 			clearInterval(interval);
-			document.removeEventListener("visibilitychange", onVisibilityChange);
+			document.removeEventListener("visibilitychange", onForeground);
+			window.removeEventListener("focus", onForeground);
+			window.removeEventListener("pageshow", onForeground);
 		};
 	}, []);
 

--- a/src/components/DeployRefresh.tsx
+++ b/src/components/DeployRefresh.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { usePlayer } from "~/components/playlist/PlayerContext";
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -9,60 +10,42 @@ const RELOAD_COOLDOWN_MS = 10 * 60 * 1000;
 /**
  * Hard-reloads the app when a new deployment goes live.
  *
- * Polls /api/version every few minutes (and whenever the app returns to the
- * foreground) and compares it against the build id baked into this bundle.
- * Never reloads mid-playback — if a video is playing, the reload waits for
- * the next pause so a nighttime deploy can't interrupt the lullaby. A
- * cooldown stopper prevents reload loops if the edge briefly keeps serving
- * the old bundle. No-op in dev, where the build id is always "dev".
+ * A React Query polls /api/version (the live deploy's build id) and compares
+ * it to the id baked into this bundle. The global QueryClient disables all
+ * auto-refetch, so this query opts back in: it polls every few minutes and
+ * refetches on window-focus + reconnect, so a reopened or reconnected client
+ * notices a new deploy promptly. Never reloads mid-playback — a running video
+ * defers the reload to the next pause so a nighttime deploy can't cut off the
+ * lullaby. A cooldown stopper prevents reload loops if the edge briefly keeps
+ * serving the old bundle. No-op in dev, where the build id is always "dev".
  * @example <DeployRefresh />
  */
 export function DeployRefresh() {
 	const player = usePlayer();
-	const staleRef = useRef(false);
-	const isPlayingRef = useRef(player.isPlaying);
-	isPlayingRef.current = player.isPlaying;
+	const current = process.env.NEXT_PUBLIC_BUILD_ID;
+	const enabled = !!current && current !== "dev";
 
-	// Playback just stopped with a reload pending — take the chance
+	const { data: liveVersion } = useQuery({
+		queryKey: ["deploy-version"],
+		queryFn: async () => {
+			const res = await fetch("/api/version", { cache: "no-store" });
+			const { version } = (await res.json()) as { version?: string };
+			return version ?? null;
+		},
+		enabled,
+		staleTime: 0,
+		refetchInterval: CHECK_INTERVAL_MS,
+		refetchOnWindowFocus: true,
+		refetchOnReconnect: true,
+		refetchOnMount: true,
+	});
+
+	const stale = enabled && !!liveVersion && liveVersion !== current;
+
+	// Reload once stale — immediately if idle, otherwise when playback stops.
 	useEffect(() => {
-		if (!player.isPlaying && staleRef.current) reload();
-	}, [player.isPlaying]);
-
-	useEffect(() => {
-		const current = process.env.NEXT_PUBLIC_BUILD_ID;
-		if (!current || current === "dev") return;
-
-		const check = async () => {
-			try {
-				const res = await fetch("/api/version", { cache: "no-store" });
-				const { version } = (await res.json()) as { version?: string };
-				if (version && version !== current) staleRef.current = true;
-			} catch {
-				// Offline or flaky network — try again next round
-			}
-			if (staleRef.current && !isPlayingRef.current) reload();
-		};
-
-		// Re-check whenever the app comes back to the foreground. Background
-		// tabs throttle the interval, so a reopen is the realistic trigger:
-		// visibilitychange (tab switch), focus (window regains focus), and
-		// pageshow (bfcache restore — the common mobile-PWA reopen, where the
-		// old bundle keeps running and no fresh load happens).
-		const onForeground = () => {
-			if (document.visibilityState === "visible") void check();
-		};
-
-		const interval = setInterval(check, CHECK_INTERVAL_MS);
-		document.addEventListener("visibilitychange", onForeground);
-		window.addEventListener("focus", onForeground);
-		window.addEventListener("pageshow", onForeground);
-		return () => {
-			clearInterval(interval);
-			document.removeEventListener("visibilitychange", onForeground);
-			window.removeEventListener("focus", onForeground);
-			window.removeEventListener("pageshow", onForeground);
-		};
-	}, []);
+		if (stale && !player.isPlaying) reload();
+	}, [stale, player.isPlaying]);
 
 	return null;
 }


### PR DESCRIPTION
Auto-refresh-on-new-deploy was wired correctly but rarely fired: the only realistic trigger was `visibilitychange`, and background tabs throttle the poll.

Replace the hand-rolled `setInterval` + focus/visibility/pageshow listeners with a `useQuery` against `/api/version` that opts back into the globally-disabled auto-refetch (the app's QueryClient turns all auto-refetch off):

- `refetchInterval` poll (paused in background — no battery drain)
- `refetchOnWindowFocus` — reopen/tab-switch
- `refetchOnReconnect` — laptop wake / phone regains signal (new; the old code had no reconnect path)

Keeps the existing behavior: never reloads mid-playback (defers to next pause), 10-min cooldown against reload loops, no-op in dev.

Verified: `bun fix` + `tsc --noEmit` clean. Runtime behavior needs two deploys to observe (open app on deploy A → deploy B → tab-switch back triggers hard reload).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv9XEikmZLLJ4VKPbzq7R2)_